### PR TITLE
fix: display help if no args provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,10 @@ var (
 
 //nolint
 func main() {
+	//print help if no command given
+	if len(os.Args) < 2 {
+		os.Args = append(os.Args, "--help")
+	}
 	ctx := kong.Parse(&CLI)
 
 	logger := logging.GetRoot()


### PR DESCRIPTION
## Related Issues
<!-- - #[ISSUE-ID]-->
N/A
## Description
<!-- Describe your changes in detail -->
For new users, if you just run `teller` with no arguments the output is not very intuitive. This PR simply displays the `--help` message if you run `teller` without arguments.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Makes `teller` a little bit more user friendly.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Local testing.

# Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Linting